### PR TITLE
Fix production api key authentication error

### DIFF
--- a/src/lib/server/cookies.ts
+++ b/src/lib/server/cookies.ts
@@ -67,11 +67,16 @@ export function clearByokCookies(res: NextResponse): void {
 }
 
 export function isEncryptedCookieEnabled(): boolean {
-  const val = process.env.BYOK_ENCRYPTED_COOKIE_ENABLED;
-  if (typeof val === "string") {
-    return val.toLowerCase() === "true";
+  const explicit = process.env.BYOK_ENCRYPTED_COOKIE_ENABLED;
+  if (typeof explicit === "string") {
+    return explicit.toLowerCase() === "true";
   }
-  // Default: enabled in dev, disabled in production
+  // Auto-enable in production when a current secret is configured, to ensure
+  // stateless BYOK works reliably across serverless instances.
+  if (process.env.NODE_ENV === "production" && process.env.BYOK_SECRET_CURRENT) {
+    return true;
+  }
+  // Default: enabled in dev, disabled in production without a secret
   return process.env.NODE_ENV !== "production";
 }
 


### PR DESCRIPTION
Auto-enable encrypted BYOK cookie in production when `BYOK_SECRET_CURRENT` is present to ensure reliable API key retrieval on Vercel.

---
<a href="https://cursor.com/background-agent?bcId=bc-880cf109-2c2f-4c07-8224-596af87f28f4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-880cf109-2c2f-4c07-8224-596af87f28f4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

