### PR TITLE
Fix API key input not opening on mobile

### DIFF
--- a/src/components/app/AppShell.tsx
+++ b/src/components/app/AppShell.tsx
@@ -8,7 +8,7 @@ import { ApiKeyManager } from "@/components/common/ApiKeyManager";
 import { FeedbackButton } from "@/components/common/FeedbackButton";
 import { FeedbackDialog } from "@/components/common/FeedbackDialog";
 import { subscribeCommands, emitCommand } from "@/lib/commandBus";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import { GrainOverlay } from "@/components/ui/GrainOverlay";
 import {
   DropdownMenu,
@@ -21,14 +21,10 @@ import { Button } from "@/components/ui/button";
 import { MoreVertical, Plus, Download, Upload, Key, MessageSquare, BookOpen, Keyboard } from "lucide-react";
 
 export function AppShell({ left, center, right }: { left: ReactNode; center: ReactNode; right: ReactNode }) {
-  const apiKeyButtonRef = useRef<HTMLButtonElement | null>(null);
   const [feedbackOpen, setFeedbackOpen] = useState(false);
 
   useEffect(() => {
     return subscribeCommands((cmd) => {
-      if (cmd === "connect-api-key") {
-        apiKeyButtonRef.current?.click();
-      }
       if (cmd === "open-feedback") {
         setFeedbackOpen(true);
       }
@@ -164,6 +160,10 @@ export function AppShell({ left, center, right }: { left: ReactNode; center: Rea
         </div>
       </SidebarProvider>
       <FeedbackDialog open={feedbackOpen} onOpenChange={setFeedbackOpen} />
+      {/* ApiKeyManager for mobile - hidden button but always mounted to handle commands */}
+      <div className="md:hidden">
+        <ApiKeyManager showButton={false} />
+      </div>
     </>
   );
 }

--- a/src/components/common/ApiKeyManager.tsx
+++ b/src/components/common/ApiKeyManager.tsx
@@ -13,13 +13,15 @@ import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
 import { toast } from "sonner";
 import { getAuthStatus, connectApiKey, disconnectApiKey } from "@/lib/api/auth";
-import { emitCommand } from "@/lib/commandBus";
+import { emitCommand, subscribeCommands } from "@/lib/commandBus";
 import { Key, Check, X } from "lucide-react";
 
 export function ApiKeyManager({
   onStatusChange,
+  showButton = true,
 }: {
   onStatusChange?: (connected: boolean) => void;
+  showButton?: boolean;
 }) {
   const [open, setOpen] = useState(false);
   const [connected, setConnected] = useState(false);
@@ -36,6 +38,15 @@ export function ApiKeyManager({
         setExpiresAt(s.expiresAt);
       } catch {}
     })();
+  }, []);
+
+  // Listen for connect-api-key command (used by mobile menu)
+  useEffect(() => {
+    return subscribeCommands((cmd) => {
+      if (cmd === "connect-api-key") {
+        setOpen(true);
+      }
+    });
   }, []);
 
   function onOpen() {
@@ -97,21 +108,23 @@ export function ApiKeyManager({
 
   return (
     <>
-      <Button
-        variant={connected ? "default" : "outline"}
-        size="sm"
-        onClick={onOpen}
-        className="gap-1.5 sm:gap-2 h-8 sm:h-9 px-2 sm:px-3 text-[10px] sm:text-xs touch-target-sm"
-      >
-        {connected ? (
-          <Check className="size-3 sm:size-3.5" />
-        ) : (
-          <Key className="size-3 sm:size-3.5" />
-        )}
-        {/* Full label on md+, short on smaller */}
-        <span className="hidden md:inline">{label}</span>
-        <span className="md:hidden">{shortLabel}</span>
-      </Button>
+      {showButton && (
+        <Button
+          variant={connected ? "default" : "outline"}
+          size="sm"
+          onClick={onOpen}
+          className="gap-1.5 sm:gap-2 h-8 sm:h-9 px-2 sm:px-3 text-[10px] sm:text-xs touch-target-sm"
+        >
+          {connected ? (
+            <Check className="size-3 sm:size-3.5" />
+          ) : (
+            <Key className="size-3 sm:size-3.5" />
+          )}
+          {/* Full label on md+, short on smaller */}
+          <span className="hidden md:inline">{label}</span>
+          <span className="md:hidden">{shortLabel}</span>
+        </Button>
+      )}
 
       <Dialog open={open} onOpenChange={setOpen}>
         <DialogContent className="max-w-[calc(100%-2rem)] sm:max-w-md">


### PR DESCRIPTION
The mobile dropdown menu emitted connect-api-key command but the ApiKeyManager component was only rendered on desktop (hidden md:flex). The apiKeyButtonRef was also never assigned to any element.

Fixed by:
- Adding command listener directly in ApiKeyManager via subscribeCommands
- Adding showButton prop to allow rendering without the trigger button
- Mounting a hidden ApiKeyManager on mobile to handle commands
- Removing unused apiKeyButtonRef from AppShell