### PR TITLE
Fix text prompt refinement error message

### DIFF
--- a/src/components/workspace/Workspace.tsx
+++ b/src/components/workspace/Workspace.tsx
@@ -219,10 +219,6 @@ export function Workspace() {
         return;
       }
     }
-    if (family !== "image" && family !== "video") {
-      toast.error("This version currently supports Image and Video prompt refinement only.");
-      return;
-    }
     setBusy(true);
     try {
       const resp = await postRefine({


### PR DESCRIPTION
Remove restriction that blocked text prompts from being refined. The text refinement functionality was already implemented but was being blocked by an early return condition.