### PR TITLE
Fix UNSUPPORTED_FAMILY error in text prompt

### DIFF
--- a/src/lib/server/refineService.ts
+++ b/src/lib/server/refineService.ts
@@ -315,9 +315,6 @@ function aggregateUsage(usages: Array<UsageMetadata | undefined>): UsageMetadata
 }
 
 export async function refine(ai: GoogleGenAI, req: RefineRequest): Promise<RefineResponse> {
-  if (req.family !== "image" && req.family !== "video") {
-    throw new Error("UNSUPPORTED_FAMILY");
-  }
   const persona = getPersonaForFamily(req.family);
   const hasImages = (req.context?.image?.assets?.length || 0) > 0;
 


### PR DESCRIPTION
Remove the UNSUPPORTED_FAMILY check that was blocking text prompts from being refined. The rest of the codebase already supports the "text" family fully (getPersonaForFamily, buildDirective, etc.).